### PR TITLE
Conversas agora são ordenadas pela data da resposta mais recente que …

### DIFF
--- a/src/App-comunicacao-escolar/Controllers/ConversasController.cs
+++ b/src/App-comunicacao-escolar/Controllers/ConversasController.cs
@@ -30,11 +30,15 @@ namespace App_comunicacao_escolar.Controllers
             {
                 int idDoUsuarioLogado = GetIdUsuarioLogado();
 
-                var applicationDbContext = _context.Conversas.Include(c => c.Participantes).Include(c => c.NumeroDeNovasMensagensNaConversa).Include(c => c.UsuariosQueArquivaramConversa);
+                var applicationDbContext = _context.Conversas
+                    .Include(c => c.Participantes)
+                    .Include(c => c.NumeroDeNovasMensagensNaConversa)
+                    .Include(c => c.UsuariosQueArquivaramConversa)
+                    .Include(c => c.Mensagens);
 
                 var conversas = from c in applicationDbContext select c;
 
-                conversas = conversas.OrderByDescending(c => c.Id);
+                conversas = conversas.OrderByDescending(c => c.Mensagens.Where(m => m.Participantes.Any(p => p.Id == idDoUsuarioLogado)).Max(m => m.DataEnvio)); ;
 
                 if (secao.Equals("Enviados"))
                 {


### PR DESCRIPTION
Conversas na caixa de mensagens agora são ordenadas pela data da ultima resposta (que inclua o usuário na lista de remetentes) em vez da data da criação original.